### PR TITLE
Remove dummy newrelic.ini for PHP 7.1

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,3 +19,5 @@
     - /etc/php/5.6/fpm/conf.d/newrelic.ini
     - /etc/php/7.0/cli/conf.d/newrelic.ini
     - /etc/php/7.0/fpm/conf.d/newrelic.ini
+    - /etc/php/7.1/cli/conf.d/newrelic.ini
+    - /etc/php/7.1/fpm/conf.d/newrelic.ini


### PR DESCRIPTION
Newrelic can't find the license key for PHP 7.1 because of the extraneous config